### PR TITLE
Add env file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.env
 tests

--- a/README.md
+++ b/README.md
@@ -354,20 +354,30 @@ These helper scripts are not necessarily required for installing and setting up 
 
 ### Adding environment variables
 
-To supply environment variable values to a script, simply prepend the command to run the script with the environment variable name and its value:
+1. To supply environment variable values to a script, simply prepend the command to run the script with the environment variable name and its value:
 
-```sh
-ENV_VAR_NAME=ENV_VAR_VALUE bash <script>
-```
+    ```sh
+    ENV_VAR_NAME=ENV_VAR_VALUE bash <script>
+    ```
 
-> [!NOTE]  
-> Supply as many `ENV_VAR_NAME` and `ENV_VAR_VALUE` pairs as you need and replace `<script>` with the actual path to the script.
+    > [!NOTE]  
+    > Supply as many `ENV_VAR_NAME` and `ENV_VAR_VALUE` pairs as you need and replace `<script>` with the actual path to the script.
 
-Alternatively, instead of setting environment variables individually on a per-script basis, you can set them globally, temporarily by exporting them in your current shell session:
+2. Alternatively, instead of setting environment variables individually on a per-script basis, you can set them globally (to your Orked repository) by using an `.env` file:
 
-```sh
-export ENV_VAR_NAME=ENV_VAR_VALUE
-```
+    At the root of the Orked repository, create an `.env` file:
+
+    ```sh
+    nano ./.env
+    ```
+
+    Add in your environment variable name and value pairs to the file, separated by newlines for each pair like so:
+
+    ```env
+    ENV_VAR_NAME=ENV_VAR_VALUE
+    ```
+
+    Now when you run any of the installer or helper scripts as is, environment variable values will be sourced accordingly from the `.env` file you have provided.
 
 ### Joining additional nodes to an existing cluster
 

--- a/helpers/hostname-resolution.sh
+++ b/helpers/hostname-resolution.sh
@@ -2,10 +2,10 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../scripts"
+SCRIPT_DIR="${SOURCE_DIR}/../scripts"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"

--- a/helpers/hostname-resolution.sh
+++ b/helpers/hostname-resolution.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 SCRIPT_DIR="${ROOT_DIR}/scripts"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SCRIPT_DIR}/utils.sh"
 
 # variables

--- a/helpers/hostname-resolution.sh
+++ b/helpers/hostname-resolution.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../scripts"
+ROOT_DIR="${SOURCE_DIR}/.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/helpers/selinux-toggle.sh
+++ b/helpers/selinux-toggle.sh
@@ -2,10 +2,10 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../scripts"
+SCRIPT_DIR="${SOURCE_DIR}/../scripts"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"

--- a/helpers/selinux-toggle.sh
+++ b/helpers/selinux-toggle.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 SCRIPT_DIR="${ROOT_DIR}/scripts"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SCRIPT_DIR}/utils.sh"
 
 # variables

--- a/helpers/selinux-toggle.sh
+++ b/helpers/selinux-toggle.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../scripts"
+ROOT_DIR="${SOURCE_DIR}/.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/helpers/update-connection.sh
+++ b/helpers/update-connection.sh
@@ -2,10 +2,10 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../scripts"
+SCRIPT_DIR="${SOURCE_DIR}/../scripts"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 # variables
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"

--- a/helpers/update-connection.sh
+++ b/helpers/update-connection.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 SCRIPT_DIR="${ROOT_DIR}/scripts"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SCRIPT_DIR}/utils.sh"
 
 # variables

--- a/helpers/update-connection.sh
+++ b/helpers/update-connection.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../scripts"
+ROOT_DIR="${SOURCE_DIR}/.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/scripts/cert-manager.sh
+++ b/scripts/cert-manager.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 DEP_DIR="${ROOT_DIR}/deps"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables

--- a/scripts/cert-manager.sh
+++ b/scripts/cert-manager.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_DIR="${SOURCE_DIR}/../deps"
+ROOT_DIR="${SOURCE_DIR}/.."
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/cert-manager.sh
+++ b/scripts/cert-manager.sh
@@ -2,7 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_PATH="${SOURCE_DIR}/../deps"
+DEP_DIR="${SOURCE_DIR}/../deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"
@@ -58,7 +58,7 @@ kubectl patch deployment cert-manager -n cert-manager --type=json -p='[
 ]'
 
 # copy cloudflare secrets to home directory
-cp -f "${DEP_PATH}/cert-manager/cloudflare-api-key-secret.yaml" "${DEP_PATH}/cert-manager/cloudflare-api-token-secret.yaml" ~
+cp -f "${DEP_DIR}/cert-manager/cloudflare-api-key-secret.yaml" "${DEP_DIR}/cert-manager/cloudflare-api-token-secret.yaml" ~
 
 # add cloudflare api key to cloudflare secrets
 sed -i "s/{{ CLOUDFLARE_API_KEY }}/${CF_API_KEY}/g" ~/cloudflare-api-key-secret.yaml
@@ -68,7 +68,7 @@ sed -i "s/{{ CLOUDFLARE_API_KEY }}/${CF_API_KEY}/g" ~/cloudflare-api-token-secre
 kubectl apply -f ~/cloudflare-api-key-secret.yaml -f ~/cloudflare-api-token-secret.yaml -n cert-manager
 
 # copy letsencrypt validation manifests to home directory
-cp -f "${DEP_PATH}/cert-manager/letsencrypt-dns-validation.yaml" "${DEP_PATH}/cert-manager/letsencrypt-http-validation.yaml" ~
+cp -f "${DEP_DIR}/cert-manager/letsencrypt-dns-validation.yaml" "${DEP_DIR}/cert-manager/letsencrypt-http-validation.yaml" ~
 
 # add cloudflare user email to letsencrypt validation manifests
 sed -i "s/{{ CLOUDFLARE_USER_EMAIL }}/${CF_EMAIL}/g" ~/letsencrypt-dns-validation.yaml

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/.."
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -3,8 +3,12 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -2,7 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_PATH="${SOURCE_DIR}/../deps"
+DEP_DIR="${SOURCE_DIR}/../deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_DIR="${SOURCE_DIR}/../deps"
+ROOT_DIR="${SOURCE_DIR}/.."
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 DEP_DIR="${ROOT_DIR}/deps"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables (experimental)

--- a/scripts/login/login.sh
+++ b/scripts/login/login.sh
@@ -5,8 +5,12 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/../.."
 SCRIPT_DIR="${ROOT_DIR}/scripts"
 UTILS_DIR="${SOURCE_DIR}/utils"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SCRIPT_DIR}/utils.sh"
 
 # variables

--- a/scripts/login/login.sh
+++ b/scripts/login/login.sh
@@ -2,11 +2,11 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/.."
+SCRIPT_DIR="${SOURCE_DIR}/.."
 UTILS_PATH="${SOURCE_DIR}/utils"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 # variables
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"

--- a/scripts/login/login.sh
+++ b/scripts/login/login.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/.."
+ROOT_DIR="${SOURCE_DIR}/../.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
 UTILS_DIR="${SOURCE_DIR}/utils"
 
 # source project files

--- a/scripts/login/login.sh
+++ b/scripts/login/login.sh
@@ -3,7 +3,7 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SCRIPT_DIR="${SOURCE_DIR}/.."
-UTILS_PATH="${SOURCE_DIR}/utils"
+UTILS_DIR="${SOURCE_DIR}/utils"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"
@@ -15,28 +15,28 @@ export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # setup yum repo and dependencies
-bash "${UTILS_PATH}/yum.sh"
+bash "${UTILS_DIR}/yum.sh"
 
 # install docker
-bash "${UTILS_PATH}/docker.sh"
+bash "${UTILS_DIR}/docker.sh"
 
 # install kubectl
-bash "${UTILS_PATH}/kubectl.sh"
+bash "${UTILS_DIR}/kubectl.sh"
 
 # install kubectx and kubens
-bash "${UTILS_PATH}/kubectx.sh" && PKG_NAME="kubens" bash "${UTILS_PATH}/kubectx.sh"
+bash "${UTILS_DIR}/kubectx.sh" && PKG_NAME="kubens" bash "${UTILS_DIR}/kubectx.sh"
 
 # install k9s
-SYS_ARCH="x86_64" PKG_SRC_VER="0.26.4" bash "${UTILS_PATH}/k9s.sh"
+SYS_ARCH="x86_64" PKG_SRC_VER="0.26.4" bash "${UTILS_DIR}/k9s.sh"
 
 # install helm
-bash "${UTILS_PATH}/helm.sh"
+bash "${UTILS_DIR}/helm.sh"
 
 # install pv-migrate
-bash "${UTILS_PATH}/pv-migrate.sh"
+bash "${UTILS_DIR}/pv-migrate.sh"
 
 # install df-pv
-bash "${UTILS_PATH}/df-pv.sh"
+bash "${UTILS_DIR}/df-pv.sh"
 
 # reboot
 run_with_sudo reboot now

--- a/scripts/login/utils/df-pv.sh
+++ b/scripts/login/utils/df-pv.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/../../.."
 
 # variables
 export PKG_NAME="${PKG_NAME:-"kubectl-df-pv"}"

--- a/scripts/login/utils/docker.sh
+++ b/scripts/login/utils/docker.sh
@@ -3,7 +3,7 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SCRIPT_DIR="${SOURCE_DIR}/../.."
-DEP_PATH="${SOURCE_DIR}/../../../deps"
+DEP_DIR="${SOURCE_DIR}/../../../deps"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"
@@ -18,7 +18,7 @@ if [ "$(is_installed "${PKG_NAME}")" = "false" ]; then
     echo "Installing ${PKG_NAME}..."
     # run installer
     # source: https://releases.rancher.com/install-docker/20.10.sh
-    run_with_sudo sh "${DEP_PATH}/login/20.10.sh"
+    run_with_sudo sh "${DEP_DIR}/login/20.10.sh"
     # create group docker
     run_with_sudo groupadd docker
     # add current user to docker group

--- a/scripts/login/utils/docker.sh
+++ b/scripts/login/utils/docker.sh
@@ -2,8 +2,9 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../.."
-DEP_DIR="${SOURCE_DIR}/../../../deps"
+ROOT_DIR="${SOURCE_DIR}/../../.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/scripts/login/utils/docker.sh
+++ b/scripts/login/utils/docker.sh
@@ -2,11 +2,11 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../.."
+SCRIPT_DIR="${SOURCE_DIR}/../.."
 DEP_PATH="${SOURCE_DIR}/../../../deps"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 # variables
 PKG_NAME="docker"

--- a/scripts/login/utils/generic-installer.sh
+++ b/scripts/login/utils/generic-installer.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../.."
+ROOT_DIR="${SOURCE_DIR}/../../.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/scripts/login/utils/generic-installer.sh
+++ b/scripts/login/utils/generic-installer.sh
@@ -2,10 +2,10 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../.."
+SCRIPT_DIR="${SOURCE_DIR}/../.."
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================

--- a/scripts/login/utils/helm.sh
+++ b/scripts/login/utils/helm.sh
@@ -2,8 +2,9 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../.."
-DEP_DIR="${SOURCE_DIR}/../../../deps"
+ROOT_DIR="${SOURCE_DIR}/../../.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/scripts/login/utils/helm.sh
+++ b/scripts/login/utils/helm.sh
@@ -2,11 +2,11 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../.."
+SCRIPT_DIR="${SOURCE_DIR}/../.."
 DEP_PATH="${SOURCE_DIR}/../../../deps"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 # variables
 PKG_NAME="helm"

--- a/scripts/login/utils/helm.sh
+++ b/scripts/login/utils/helm.sh
@@ -3,7 +3,7 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SCRIPT_DIR="${SOURCE_DIR}/../.."
-DEP_PATH="${SOURCE_DIR}/../../../deps"
+DEP_DIR="${SOURCE_DIR}/../../../deps"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"
@@ -18,7 +18,7 @@ if [ "$(is_installed "${PKG_NAME}")" = "false" ]; then
     echo "Installing ${PKG_NAME}..."
     # run installer
     # source: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-    run_with_sudo bash "${DEP_PATH}/login/helm.sh"
+    run_with_sudo bash "${DEP_DIR}/login/helm.sh"
 else
     echo "${PKG_NAME} is already installed"
 fi

--- a/scripts/login/utils/k9s.sh
+++ b/scripts/login/utils/k9s.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/../../.."
 
 # variables
 export PKG_NAME="${PKG_NAME:-"k9s"}"

--- a/scripts/login/utils/kubectl.sh
+++ b/scripts/login/utils/kubectl.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/../../.."
 
 # variables
 export PKG_NAME="${PKG_NAME:-"kubectl"}"

--- a/scripts/login/utils/kubectx.sh
+++ b/scripts/login/utils/kubectx.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/../../.."
 
 # variables
 export PKG_NAME="${PKG_NAME:-"kubectx"}"

--- a/scripts/login/utils/pv-migrate.sh
+++ b/scripts/login/utils/pv-migrate.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/../../.."
 
 # variables
 export PKG_NAME="${PKG_NAME:-"pv-migrate"}"

--- a/scripts/login/utils/yum.sh
+++ b/scripts/login/utils/yum.sh
@@ -2,8 +2,9 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_DIR="${SOURCE_DIR}/../.."
-DEP_DIR="${SOURCE_DIR}/../../../deps"
+ROOT_DIR="${SOURCE_DIR}/../../.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"

--- a/scripts/login/utils/yum.sh
+++ b/scripts/login/utils/yum.sh
@@ -3,7 +3,7 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SCRIPT_DIR="${SOURCE_DIR}/../.."
-DEP_PATH="${SOURCE_DIR}/../../../deps"
+DEP_DIR="${SOURCE_DIR}/../../../deps"
 
 # source project files
 source "${SCRIPT_DIR}/utils.sh"
@@ -18,7 +18,7 @@ run_with_sudo yum update -y
 run_with_sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 # install dependencies
-run_with_sudo yum install -y $(echo $(<"${DEP_PATH}/login/yum.txt") | tr "\n" " ")
+run_with_sudo yum install -y $(echo $(<"${DEP_DIR}/login/yum.txt") | tr "\n" " ")
 
 # clean up cache and unused dependencies
 run_with_sudo yum clean all -y && run_with_sudo yum autoremove -y

--- a/scripts/login/utils/yum.sh
+++ b/scripts/login/utils/yum.sh
@@ -2,11 +2,11 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-SCRIPT_PATH="${SOURCE_DIR}/../.."
+SCRIPT_DIR="${SOURCE_DIR}/../.."
 DEP_PATH="${SOURCE_DIR}/../../../deps"
 
 # source project files
-source "${SCRIPT_PATH}/utils.sh"
+source "${SCRIPT_DIR}/utils.sh"
 
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================

--- a/scripts/longhorn.sh
+++ b/scripts/longhorn.sh
@@ -2,7 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_PATH="${SOURCE_DIR}/../deps"
+DEP_DIR="${SOURCE_DIR}/../deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"
@@ -73,25 +73,25 @@ done
 
 # install open-iscsi
 # source: https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/deploy/prerequisite/longhorn-iscsi-installation.yaml
-kubectl apply -f "${DEP_PATH}/longhorn/longhorn-iscsi-installation.yaml"
+kubectl apply -f "${DEP_DIR}/longhorn/longhorn-iscsi-installation.yaml"
 
 # wait for longhorn-iscsi-installation to be ready
 wait_for_pods default longhorn-iscsi-installation
 
 # install NFSv4 client
 # source: https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/deploy/prerequisite/longhorn-nfs-installation.yaml
-kubectl apply -f "${DEP_PATH}/longhorn/longhorn-nfs-installation.yaml"
+kubectl apply -f "${DEP_DIR}/longhorn/longhorn-nfs-installation.yaml"
 
 # wait for longhorn-nfs-installation to be ready
 wait_for_pods default longhorn-nfs-installation
 
 # ensure nodes have all the necessary tools to install longhorn
 # source: https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/scripts/environment_check.sh
-bash "${DEP_PATH}/longhorn/environment_check.sh"
+bash "${DEP_DIR}/longhorn/environment_check.sh"
 
 # install longhorn
 # source: https://raw.githubusercontent.com/longhorn/longhorn/v1.4.1/deploy/longhorn.yaml
-kubectl apply -f "${DEP_PATH}/longhorn/longhorn.yaml"
+kubectl apply -f "${DEP_DIR}/longhorn/longhorn.yaml"
 
 # wait for longhorn to be ready
 wait_for_pods longhorn-system

--- a/scripts/longhorn.sh
+++ b/scripts/longhorn.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 DEP_DIR="${ROOT_DIR}/deps"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables

--- a/scripts/longhorn.sh
+++ b/scripts/longhorn.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_DIR="${SOURCE_DIR}/../deps"
+ROOT_DIR="${SOURCE_DIR}/.."
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/metallb.sh
+++ b/scripts/metallb.sh
@@ -2,7 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_PATH="${SOURCE_DIR}/../deps"
+DEP_DIR="${SOURCE_DIR}/../deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"
@@ -21,13 +21,13 @@ fi
 
 # install metallb
 # source: https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
-kubectl apply -f "${DEP_PATH}/metallb/metallb-native.yaml"
+kubectl apply -f "${DEP_DIR}/metallb/metallb-native.yaml"
 
 # wait until no pods are pending
 wait_for_pods metallb-system
 
 # copy metallb-configuration.yaml to home directory
-cp -f "${DEP_PATH}/metallb/metallb-configuration.yaml" ~
+cp -f "${DEP_DIR}/metallb/metallb-configuration.yaml" ~
 
 # replace {{ IPv4_RANGE }} in metallb-configuration.yaml
 if [ "${#ipv4_addresses[@]}" -eq 1 ]; then

--- a/scripts/metallb.sh
+++ b/scripts/metallb.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 DEP_DIR="${ROOT_DIR}/deps"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 

--- a/scripts/metallb.sh
+++ b/scripts/metallb.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_DIR="${SOURCE_DIR}/../deps"
+ROOT_DIR="${SOURCE_DIR}/.."
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/passwordless.sh
+++ b/scripts/passwordless.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/.."
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/passwordless.sh
+++ b/scripts/passwordless.sh
@@ -3,8 +3,12 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables

--- a/scripts/rke.sh
+++ b/scripts/rke.sh
@@ -2,6 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/.."
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"

--- a/scripts/rke.sh
+++ b/scripts/rke.sh
@@ -3,8 +3,12 @@
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables

--- a/scripts/smb.sh
+++ b/scripts/smb.sh
@@ -2,7 +2,7 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_PATH="${SOURCE_DIR}/../deps"
+DEP_DIR="${SOURCE_DIR}/../deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"
@@ -57,7 +57,7 @@ fi
 
 # install smb storage class
 # source: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/deploy/example/storageclass-smb.yaml
-kubectl apply -f "${DEP_PATH}/smb/storageclass-smb.yaml"
+kubectl apply -f "${DEP_DIR}/smb/storageclass-smb.yaml"
 
 # wait for smb to be ready
 # TODO: not sure what to wait for to determine if smb storageclass is ready

--- a/scripts/smb.sh
+++ b/scripts/smb.sh
@@ -4,8 +4,12 @@
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ROOT_DIR="${SOURCE_DIR}/.."
 DEP_DIR="${ROOT_DIR}/deps"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
 
 # source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
 source "${SOURCE_DIR}/utils.sh"
 
 # variables

--- a/scripts/smb.sh
+++ b/scripts/smb.sh
@@ -2,7 +2,8 @@
 
 # get script source
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEP_DIR="${SOURCE_DIR}/../deps"
+ROOT_DIR="${SOURCE_DIR}/.."
+DEP_DIR="${ROOT_DIR}/deps"
 
 # source project files
 source "${SOURCE_DIR}/utils.sh"


### PR DESCRIPTION
# Changes

- Partially addresses #13 
- Renamed scripts vars; `SCRIPT_DIR`, `DEP_DIR`, AND `UTILS_DIR` for consistency
- Added `ROOT_DIR` to each script to better track script positioning
- Added `.env` file to ignore list
- Added support for sourcing env variables from `.env` file if supplied
- Added guide on how to provide an `.env` file