### PR TITLE
Remove custom ingress ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ For details on how to use each of these scripts and what they are for, please re
     | --- | --- | --- | --- |
     | `NGINX_HTTP` | The port used for routing HTTP traffic to the NGINX ingress controller. | `8080` | `80` |
     | `NGINX_HTTPS` | The port used for routing HTTPS traffic to the NGINX ingress controller. | `8443` | `443` |
-    | `NGINX_WEBHOOK` | The port used for handling admission webhook traffic by the NGINX ingress controller. | `8554` | `8443` |
 
 ---
 

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -40,11 +40,11 @@ helm upgrade --install ingress-nginx ingress-nginx \
 --namespace ingress-nginx \
 --create-namespace \
 --version v4.6.1 \
---set controller.containerPort.http="${NGINX_HTTP}" \
---set controller.containerPort.https="${NGINX_HTTPS}" \
+# --set controller.containerPort.http="${NGINX_HTTP}" \
+# --set controller.containerPort.https="${NGINX_HTTPS}" \
 --set controller.service.ports.http="${NGINX_HTTP}" \
 --set controller.service.ports.https="${NGINX_HTTPS}" \
---set controller.admissionWebhooks.port="${NGINX_WEBHOOK}" \
+# --set controller.admissionWebhooks.port="${NGINX_WEBHOOK}" \
 --set controller.admissionWebhooks.service.servicePort="${NGINX_HTTPS}" \
 --wait
 

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -15,13 +15,13 @@ source "${SOURCE_DIR}/utils.sh"
 # variables (experimental)
 NGINX_HTTP="${NGINX_HTTP:-"80"}"
 NGINX_HTTPS="${NGINX_HTTPS:-"443"}"
-NGINX_WEBHOOK="${NGINX_WEBHOOK:-"8443"}"
+# NGINX_WEBHOOK="${NGINX_WEBHOOK:-"8443"}"
 
 # env variables
 env_variables=(
     "NGINX_HTTP"
     "NGINX_HTTPS"
-    "NGINX_WEBHOOK"
+    # "NGINX_WEBHOOK"
 )
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -40,11 +40,8 @@ helm upgrade --install ingress-nginx ingress-nginx \
 --namespace ingress-nginx \
 --create-namespace \
 --version v4.6.1 \
-# --set controller.containerPort.http="${NGINX_HTTP}" \
-# --set controller.containerPort.https="${NGINX_HTTPS}" \
 --set controller.service.ports.http="${NGINX_HTTP}" \
 --set controller.service.ports.https="${NGINX_HTTPS}" \
-# --set controller.admissionWebhooks.port="${NGINX_WEBHOOK}" \
 --set controller.admissionWebhooks.service.servicePort="${NGINX_HTTPS}" \
 --wait
 


### PR DESCRIPTION
# Changes

- Removed the ability to set custom container ports for HTTP, HTTPS, and Admission webhook
- Deprecated the now unused `NGINX_WEBHOOK` env variable