### PR TITLE
Helper script to stop cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,9 @@ These helper scripts are not necessarily required for installing and setting up 
 ### Stop cluster
 
 > [!TIP]  
-> This script is experimental and should be used with caution. This script may also require the Longhorn setting `allow-node-drain-with-last-healthy-replica` to be set to `false`. For the best result, it is highly recommended to shut down the cluster on a per-node basis as you make necessary changes to the node.
+> This script is experimental and should be used with caution. For the best result, it is highly recommended to stop or shut down the cluster on a per-node basis as you make necessary changes to the node. This script may also require the Longhorn setting `allow-node-drain-with-last-healthy-replica` to be set to `false`.
 
-- This script automates the process of gracefully stopping a Kubernetes cluster by cordoning and draining Worker nodes, stopping all Kubernetes processes, uncordoning the Worker nodes, and stopping all Master nodes (in reverse order). It also comes with the option to shut down all nodes in the entire cluster after they have been stopped.
+- This script automates the process of gracefully stopping a Kubernetes cluster by cordoning and draining Worker nodes, stopping all Kubernetes processes, uncordoning the Worker nodes, and stopping the Master nodes. It also comes with the option to shut down all nodes in the entire cluster after they have been stopped.
 
 - From the root of the repository, run the [script](./helpers/stop-cluster.sh) on the **Login node**:
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ These helper scripts are not necessarily required for installing and setting up 
     | `SSH_PORT` | The SSH port used on the Kubernetes nodes. | `2200` | `22` |
     | `MASTER_NODES` | Space-separated list of hostnames for Kubernetes master nodes. | `"orked-master-1.example.com orked-master-2.example.com orked-master-3.example.com"` | - |
     | `WORKER_NODES` | Space-separated list of hostnames for Kubernetes worker nodes. | `"orked-worker-1.example.com orked-worker-2.example.com orked-worker-3.example.com"` | - |
+    | `DRAIN_OPTS` | Space-separated list of options to pass to the `drain` command, with each option prefixed by `--`. | `"disable-eviction grace-period=0"` | - |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ These helper scripts are not necessarily required for installing and setting up 
     | `SSH_PORT` | The SSH port used on the Kubernetes nodes. | `2200` | `22` |
     | `MASTER_NODES` | Space-separated list of hostnames for Kubernetes master nodes. | `"orked-master-1.example.com orked-master-2.example.com orked-master-3.example.com"` | - |
     | `WORKER_NODES` | Space-separated list of hostnames for Kubernetes worker nodes. | `"orked-worker-1.example.com orked-worker-2.example.com orked-worker-3.example.com"` | - |
-    | `DRAIN_OPTS` | Space-separated list of options to pass to the `drain` command, with each option prefixed by `--`. | `"disable-eviction grace-period=0"` | - |
+    | `DRAIN_OPTS` | Additional options to pass to the `drain` command. | `"--disable-eviction --grace-period 0"` | - |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ These helper scripts are not necessarily required for installing and setting up 
 ### Stop cluster
 
 > [!TIP]  
-> This script is still experimental and should be used with caution. This script may also require the Longhorn setting `allow-node-drain-with-last-healthy-replica` to be set to `false` (default: `true`).
+> This script is experimental and should be used with caution. This script may also require the Longhorn setting `allow-node-drain-with-last-healthy-replica` to be set to `false`. For the best result, it is highly recommended to shut down the cluster on a per-node basis as you make necessary changes to the node.
 
 - This script automates the process of gracefully stopping a Kubernetes cluster by cordoning and draining Worker nodes, stopping all Kubernetes processes, uncordoning the Worker nodes, and stopping all Master nodes (in reverse order). It also comes with the option to shut down all nodes in the entire cluster after they have been stopped.
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ These helper scripts are not necessarily required for installing and setting up 
 ### Resize Longhorn disk
 
 > [!TIP]  
-> This script requires [Longhorn storage](#longhorn-storage) to have already been set up. The Kubernetes cluster must not be operational during this process, it is recommended to [shut down the entire cluster](#stop-cluster) and only boot up the Worker nodes prior to running this script.
+> This script requires [Longhorn storage](#longhorn-storage) to have already been set up. On a per-node basis, it is recommended to [shut down the Worker node](#stop-cluster), increase its disk storage size, boot up the Worker node, and [stop the Worker node](#stop-cluster) (without shutting down) prior to running this script.
 
 - This script automates the process of expanding the size of the Longhorn storage partition on the Worker nodes, assuming the underlying Longhorn disk on each node has already been resized.
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ These helper scripts are not necessarily required for installing and setting up 
 ### Resize Longhorn disk
 
 > [!TIP]  
-> This script requires [Longhorn storage](#longhorn-storage) to have already been set up. The Kubernetes cluster must not be operational during this process, it is recommended to shut down the entire cluster and only boot up the Worker nodes prior to running this script.
+> This script requires [Longhorn storage](#longhorn-storage) to have already been set up. The Kubernetes cluster must not be operational during this process, it is recommended to [shut down the entire cluster](#stop-cluster) and only boot up the Worker nodes prior to running this script.
 
 - This script automates the process of expanding the size of the Longhorn storage partition on the Worker nodes, assuming the underlying Longhorn disk on each node has already been resized.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
     - [Update connection](#update-connection)
     - [Toggle SELinux](#toggle-selinux)
     - [Resize Longhorn disk](#resize-longhorn-disk)
+    - [Stop cluster](#stop-cluster)
   - [Additional resources](#additional-resources)
     - [Adding environment variables](#adding-environment-variables)
     - [Joining additional nodes to an existing cluster](#joining-additional-nodes-to-an-existing-cluster)
@@ -423,6 +424,31 @@ These helper scripts are not necessarily required for installing and setting up 
     | `SUDO_PASSWD` | The sudo password of the service user account. | `mypassword` | - |
     | `SSH_PORT` | The SSH port used on the Kubernetes nodes. | `2200` | `22` |
     | `LONGHORN_STORAGE_DEVICE` | The Longhorn storage device name. | `/dev/sdc` | `/dev/sdb` |
+    | `WORKER_NODES` | Space-separated list of hostnames for Kubernetes worker nodes. | `"orked-worker-1.example.com orked-worker-2.example.com orked-worker-3.example.com"` | - |
+
+---
+
+### Stop cluster
+
+> [!TIP]  
+> This script is still experimental and should be used with caution.
+
+- This script automates the process of gracefully stopping a Kubernetes cluster by cordoning and draining Worker nodes, stopping all Kubernetes processes, uncordoning the Worker nodes, and stopping all Master nodes (in reverse order). It also comes with the option to shut down all nodes in the entire cluster after they have been stopped.
+
+- From the root of the repository, run the [script](./helpers/stop-cluster.sh) on the **Login node**:
+
+    ```sh
+    bash ./helpers/stop-cluster.sh
+    ```
+
+- Optional [environment variables](#adding-environment-variables):
+
+    | **Option** | **Description** | **Sample** | **Default** |
+    | --- | --- | --- | --- |
+    | `SERVICE_USER` | The username of the service user account. | `myuser` | - |
+    | `SUDO_PASSWD` | The sudo password of the service user account. | `mypassword` | - |
+    | `SSH_PORT` | The SSH port used on the Kubernetes nodes. | `2200` | `22` |
+    | `MASTER_NODES` | Space-separated list of hostnames for Kubernetes master nodes. | `"orked-master-1.example.com orked-master-2.example.com orked-master-3.example.com"` | - |
     | `WORKER_NODES` | Space-separated list of hostnames for Kubernetes worker nodes. | `"orked-worker-1.example.com orked-worker-2.example.com orked-worker-3.example.com"` | - |
 
 ---

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ These helper scripts are not necessarily required for installing and setting up 
 ### Stop cluster
 
 > [!TIP]  
-> This script is still experimental and should be used with caution.
+> This script is still experimental and should be used with caution. This script may also require the Longhorn setting `allow-node-drain-with-last-healthy-replica` to be set to `false` (default: `true`).
 
 - This script automates the process of gracefully stopping a Kubernetes cluster by cordoning and draining Worker nodes, stopping all Kubernetes processes, uncordoning the Worker nodes, and stopping all Master nodes (in reverse order). It also comes with the option to shut down all nodes in the entire cluster after they have been stopped.
 

--- a/helpers/resize-longhorn-disk.sh
+++ b/helpers/resize-longhorn-disk.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SCRIPT_DIR}/utils.sh"
 
+# print title
+print_title "resize longhorn"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -31,7 +34,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "resize longhorn"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/helpers/resize-longhorn-disk.sh
+++ b/helpers/resize-longhorn-disk.sh
@@ -91,6 +91,10 @@ for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
 
             # verify new partition size
             df -h "/var/lib/longhorn"
+
+            # reboot node
+            echo "Rebooting node ${worker_hostname} in 5s..."
+            sleep 5 && reboot now
 ROOT
 EOF
 done

--- a/helpers/selinux-toggle.sh
+++ b/helpers/selinux-toggle.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SCRIPT_DIR}/utils.sh"
 
+# print title
+print_title "selinux"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -29,7 +32,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "selinux"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# get script source
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="${SOURCE_DIR}/.."
+SCRIPT_DIR="${ROOT_DIR}/scripts"
+ENV_FILE="${ENV_FILE:-"${ROOT_DIR}/.env"}"
+
+# source project files
+if [ -f "${ENV_FILE}" ]; then
+    source "${ENV_FILE}"
+fi
+source "${SCRIPT_DIR}/utils.sh"
+
+# print title
+print_title "stop cluster"
+
+# variables
+SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
+export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
+SSH_PORT="${SSH_PORT:-"22"}"
+MASTER_NODES=(${MASTER_NODES:-$(get_values "hostname of master node")})
+WORKER_NODES=(${WORKER_NODES:-$(get_values "hostname of worker node")})
+SHUTDOWN_NODES="$(get_bool "shutdown all nodes")"; echo
+
+# env variables
+env_variables=(
+    "SERVICE_USER"
+    "SUDO_PASSWD"
+    "SSH_PORT"
+    "MASTER_NODES"
+    "WORKER_NODES"
+    "SHUTDOWN_NODES"
+)
+
+# ================= DO NOT EDIT BEYOND THIS LINE =================
+
+# get user confirmation
+confirm_values "${env_variables[@]}"
+confirm="${?}"
+if [ "${confirm}" -ne 0 ]; then
+    exit "${confirm}"
+fi
+
+# flag all worker nodes as unschedulable
+for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
+    worker_hostname="${WORKER_NODES[${i}]}"
+    echo "Cordoning worker: ${worker_hostname}"
+    kubectl cordon "${worker_hostname}"
+done
+
+# drain all worker nodes
+for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
+    worker_hostname="${WORKER_NODES[${i}]}"
+    echo "Draining worker: ${worker_hostname}"
+    kubectl drain "${worker_hostname}" --force --delete-emptydir-data --ignore-daemonsets --timeout 0
+    # kill worker node
+    echo "Killing worker: ${worker_hostname}"
+    ssh "${SERVICE_USER}@${worker_hostname}" -p "${SSH_PORT}" 'bash -s' <<- EOF
+        # kill all kubernetes processes
+        echo "${SUDO_PASSWD}" | sudo -S rke2-killall.sh
+EOF
+    # wait for worker nodes to drain completely
+    wait_for_node_readiness "${worker_hostname}" "false"
+    # shut down worker nodes if specified
+    if [ "${SHUTDOWN_NODES}" == "true" ]; then
+        echo "Shutting down worker: ${worker_hostname} in 5s..."
+        sleep 5
+        # shut down worker node
+        ssh "${SERVICE_USER}@${worker_hostname}" -p "${SSH_PORT}" 'bash -s' <<- EOF
+            # shutdown the node
+            echo "${SUDO_PASSWD}" | sudo -S shutdown now
+EOF
+    fi
+done
+
+# flag all worker nodes as schedulable
+for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
+    worker_hostname="${WORKER_NODES[${i}]}"
+    echo "Uncordoning worker: ${worker_hostname}"
+    kubectl uncordon "${worker_hostname}"
+done
+
+# stop master nodes in reverse order
+for ((i = "${#MASTER_NODES[@]}" - 1; i >= 0; i--)); do
+    master_hostname="${MASTER_NODES[${i}]}"
+    # kill master node
+    echo "Killing master: ${worker_hostname}"
+    # remote login into master node
+    ssh "${SERVICE_USER}@${master_hostname}" -p "${SSH_PORT}" 'bash -s' <<- EOF
+        # kill all kubernetes processes
+        echo "${SUDO_PASSWD}" | sudo -S rke2-killall.sh
+        # shut down master nodes if specified
+        if [ "${SHUTDOWN_NODES}" == "true" ]; then
+            echo "Shutting down master: ${master_hostname} in 5s..."
+            sleep 5
+            echo "${SUDO_PASSWD}" | sudo -S shutdown now
+        fi
+EOF
+done

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -22,7 +22,7 @@ SSH_PORT="${SSH_PORT:-"22"}"
 MASTER_NODES=(${MASTER_NODES:-$(get_values "hostname of master node")})
 WORKER_NODES=(${WORKER_NODES:-$(get_values "hostname of worker node")})
 SHUTDOWN_NODES="$(get_bool "shutdown all nodes")"; echo
-DRAIN_OPTS=$([ -n "${DRAIN_OPTS}" ] && echo "${DRAIN_OPTS}" | tr ' ' '\n' | sed 's/^/--/' | tr '\n' ' ' | sed 's/ $//' || echo "")
+DRAIN_OPTS="${DRAIN_OPTS:+ ${DRAIN_OPTS}}"
 
 # env variables
 env_variables=(
@@ -54,7 +54,7 @@ done
 for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
     worker_hostname="${WORKER_NODES[${i}]}"
     echo "Draining worker: ${worker_hostname}"
-    kubectl drain "${worker_hostname}" --force --delete-emptydir-data --ignore-daemonsets --timeout 0 "${DRAIN_OPTS}"
+    kubectl drain "${worker_hostname}" --force --delete-emptydir-data --ignore-daemonsets --timeout 0"${DRAIN_OPTS}"
     # kill worker node
     echo "Killing worker: ${worker_hostname}"
     ssh "${SERVICE_USER}@${worker_hostname}" -p "${SSH_PORT}" 'bash -s' <<- EOF

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -85,14 +85,17 @@ EOF
             echo "${SUDO_PASSWD}" | sudo -S shutdown now
 EOF
     fi
-done
-
-# flag all worker nodes as schedulable
-for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
-    worker_hostname="${WORKER_NODES[${i}]}"
+    # uncordon worker node
     echo "Uncordoning worker: ${worker_hostname}"
     kubectl uncordon "${worker_hostname}"
 done
+
+# flag all worker nodes as schedulable
+# for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
+#     worker_hostname="${WORKER_NODES[${i}]}"
+#     echo "Uncordoning worker: ${worker_hostname}"
+#     kubectl uncordon "${worker_hostname}"
+# done
 
 # stop master nodes in reverse order
 for ((i = "${#MASTER_NODES[@]}" - 1; i >= 0; i--)); do

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -32,12 +32,20 @@ env_variables=(
     "MASTER_NODES"
     "WORKER_NODES"
     "SHUTDOWN_NODES"
+    "DRAIN_OPTS"
+)
+
+# optional variables
+opt_variables=(
+    "MASTER_NODES"
+    "WORKER_NODES"
+    "DRAIN_OPTS"
 )
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-confirm_values "${env_variables[@]}"
+confirm_values "${env_variables[@]}" "${opt_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then
     exit "${confirm}"

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -52,15 +52,19 @@ if [ "${confirm}" -ne 0 ]; then
 fi
 
 # flag all worker nodes as unschedulable
-for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
-    worker_hostname="${WORKER_NODES[${i}]}"
-    echo "Cordoning worker: ${worker_hostname}"
-    kubectl cordon "${worker_hostname}"
-done
+# for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
+#     worker_hostname="${WORKER_NODES[${i}]}"
+#     echo "Cordoning worker: ${worker_hostname}"
+#     kubectl cordon "${worker_hostname}"
+# done
 
 # drain all worker nodes
 for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
     worker_hostname="${WORKER_NODES[${i}]}"
+    # cordon worker node
+    echo "Cordoning worker: ${worker_hostname} in 5s..."
+    sleep 5 && kubectl cordon "${worker_hostname}"
+    # drain worker node
     echo "Draining worker: ${worker_hostname}"
     kubectl drain "${worker_hostname}" --force --delete-emptydir-data --ignore-daemonsets --timeout 0"${DRAIN_OPTS}"
     # kill worker node

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -61,7 +61,7 @@ fi
 # drain all worker nodes
 for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
     worker_hostname="${WORKER_NODES[${i}]}"
-    # cordon worker node
+    # flag worker node as unschedulable
     echo "Cordoning worker: ${worker_hostname} in 5s..."
     sleep 5 && kubectl cordon "${worker_hostname}"
     # drain worker node
@@ -85,7 +85,7 @@ EOF
             echo "${SUDO_PASSWD}" | sudo -S shutdown now
 EOF
     fi
-    # uncordon worker node
+    # flag worker node as schedulable
     echo "Uncordoning worker: ${worker_hostname}"
     kubectl uncordon "${worker_hostname}"
 done

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -22,6 +22,7 @@ SSH_PORT="${SSH_PORT:-"22"}"
 MASTER_NODES=(${MASTER_NODES:-$(get_values "hostname of master node")})
 WORKER_NODES=(${WORKER_NODES:-$(get_values "hostname of worker node")})
 SHUTDOWN_NODES="$(get_bool "shutdown all nodes")"; echo
+DRAIN_OPTS=$([ -n "${DRAIN_OPTS}" ] && echo "${DRAIN_OPTS}" | tr ' ' '\n' | sed 's/^/--/' | tr '\n' ' ' | sed 's/ $//' || echo "")
 
 # env variables
 env_variables=(
@@ -53,7 +54,7 @@ done
 for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
     worker_hostname="${WORKER_NODES[${i}]}"
     echo "Draining worker: ${worker_hostname}"
-    kubectl drain "${worker_hostname}" --force --delete-emptydir-data --ignore-daemonsets --timeout 0
+    kubectl drain "${worker_hostname}" --force --delete-emptydir-data --ignore-daemonsets --timeout 0 "${DRAIN_OPTS}"
     # kill worker node
     echo "Killing worker: ${worker_hostname}"
     ssh "${SERVICE_USER}@${worker_hostname}" -p "${SSH_PORT}" 'bash -s' <<- EOF

--- a/helpers/stop-cluster.sh
+++ b/helpers/stop-cluster.sh
@@ -69,7 +69,7 @@ for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
         # kill all kubernetes processes
         echo "${SUDO_PASSWD}" | sudo -S rke2-killall.sh
 EOF
-    # wait for worker nodes to drain completely
+    # wait for worker node to be dead
     wait_for_node_readiness "${worker_hostname}" "false"
     # shut down worker nodes if specified
     if [ "${SHUTDOWN_NODES}" == "true" ]; then

--- a/helpers/update-connection.sh
+++ b/helpers/update-connection.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SCRIPT_DIR}/utils.sh"
 
+# print title
+print_title "connection"
+
 # variables
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
 IFCFG_INTERFACE="${IFCFG_INTERFACE:-"$(get_data "INTERFACE")"}"
@@ -49,7 +52,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "connection"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/cert-manager.sh
+++ b/scripts/cert-manager.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "cert-manager"
+
 # variables
 CF_EMAIL="${CF_EMAIL:-"$(get_data "Cloudflare user email")"}"
 CF_API_KEY="${CF_API_KEY:-"$(get_data "Cloudflare API key")"}"
@@ -25,7 +28,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "cert-manager"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -11,6 +11,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "node configuration"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -34,7 +37,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "node configuration"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/hostname-resolution.sh
+++ b/scripts/hostname-resolution.sh
@@ -11,6 +11,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "hostname resolution"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -44,7 +47,6 @@ env_variables=(
 # get_kv_pairs worker_dns_map "IP of worker node"
 
 # get user confirmation
-print_title "hostname resolution"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/ingress.sh
+++ b/scripts/ingress.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "ingress"
+
 # variables (experimental)
 NGINX_HTTP="${NGINX_HTTP:-"80"}"
 NGINX_HTTPS="${NGINX_HTTPS:-"443"}"
@@ -27,7 +30,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "ingress"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/login/login.sh
+++ b/scripts/login/login.sh
@@ -13,6 +13,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SCRIPT_DIR}/utils.sh"
 
+# print title
+print_title "login node"
+
 # variables
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
 
@@ -24,7 +27,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "login node"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/longhorn.sh
+++ b/scripts/longhorn.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "longhorn"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -31,7 +34,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "longhorn"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/longhorn.sh
+++ b/scripts/longhorn.sh
@@ -64,7 +64,7 @@ for ((i = 0; i < "${#WORKER_NODES[@]}"; i++)); do
             mkdir -p /var/lib/longhorn
 
             # format dedicated data storage
-            if ! lsblk -no FSTYPE "${device}" | grep -q .; then
+            if ! lsblk -no FSTYPE "${LONGHORN_STORAGE_DEVICE}" | grep -q .; then
                 mkfs.ext4 ${LONGHORN_STORAGE_DEVICE} && echo "Formatted ${LONGHORN_STORAGE_DEVICE} to ext4 successfully" || { echo "ERROR: Failed to format ${LONGHORN_STORAGE_DEVICE}"; exit 1; }
             else
                 echo "WARNING: ${LONGHORN_STORAGE_DEVICE} has already been formatted"

--- a/scripts/metallb.sh
+++ b/scripts/metallb.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "metallb"
+
 # variables
 METALLB_IP=(${METALLB_IP:-$(get_values "private IPv4 address")})
 
@@ -23,7 +26,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "metallb"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/passwordless.sh
+++ b/scripts/passwordless.sh
@@ -11,6 +11,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "passwordless"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 SSH_PORT="${SSH_PORT:-"22"}"
@@ -38,7 +41,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "passwordless"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/rke.sh
+++ b/scripts/rke.sh
@@ -11,6 +11,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "rke2"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -40,7 +43,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "rke2"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/smb.sh
+++ b/scripts/smb.sh
@@ -12,6 +12,9 @@ if [ -f "${ENV_FILE}" ]; then
 fi
 source "${SOURCE_DIR}/utils.sh"
 
+# print title
+print_title "SMB"
+
 # variables
 SERVICE_USER="${SERVICE_USER:-"$(get_data "service user account")"}"
 export SUDO_PASSWD="${SUDO_PASSWD:-"$(get_password "sudo password")"}"
@@ -33,7 +36,6 @@ env_variables=(
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 # get user confirmation
-print_title "SMB"
 confirm_values "${env_variables[@]}"
 confirm="${?}"
 if [ "${confirm}" -ne 0 ]; then

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -127,10 +127,13 @@ function get_kv_arrays() {
 # confirm script values
 function confirm_values() {
     local values=""
+    local variables=("${@:1:${#env_variables[@]}}")
+    local optional=("${@:$((${#env_variables[@]} + 1))}")
     # check if all variables are set
-    for var in "${@}"; do
+    for var in "${variables[@]}"; do
         local -n value="${var}"
-        if [ -z "${value}" ]; then
+        # check if the variable is optional
+        if [ -z "${value}" ] && [[ ! " ${optional[*]} " =~ " ${var} " ]]; then
             echo "ERROR: \"${var}\" has not been set"
             return 1
         fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -253,7 +253,6 @@ function wait_for_node_readiness() {
             echo "ERROR: Could not fetch the status for node '${node_name}'"
             return 1
         else
-            echo "Waiting for '${node_name}' to be ${desired_readiness}..."
             sleep 5
         fi
     done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -250,8 +250,7 @@ function wait_for_node_readiness() {
             echo "Node '${node_name}' is ${node_readiness}!"
             break
         elif [ -z "${node_readiness}" ]; then
-            echo "ERROR: Could not fetch the status for node '${node_name}'"
-            return 1
+            echo "ERROR: Could not fetch the status for node '${node_name}'"; return 1
         else
             sleep 5
         fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -14,6 +14,16 @@ function get_data() {
     echo -n "${data}"
 }
 
+# get bool from user input
+function get_bool() {
+    read -p "Do you wish to ${1}? [y/N]: " -n 1 -r
+    if [[ ! ${REPLY} =~ ^[Yy]$ ]]; then
+        echo -n "false"
+    else
+        echo -n "true"
+    fi
+}
+
 # get password from user input
 function get_password() {
     local hint="${1:-"password"}"


### PR DESCRIPTION
# Changes

- Added method that checks/waits for cluster node readiness
- Added method to get boolean data
- Script titles have been moved to be printed at the start of the script
- Fixed longhorn script checking the wrong env variable when prior to formatting storage
- Updated helper script to reboot node after resizing longhorn storage
- Added new helper script to stop/shut down the entire cluster
- Updated `confirm_values` method to accept flagging certain variables as optional
- Updated tip on how to utilise the helper script to resize longhorn disk

# Issues addressed

- #25
- (Partial) #20